### PR TITLE
Fix compatibility with Redux DevTools.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "license": "CC0-1.0",
   "repository": "nealgranger/redux-promise-wait",
   "scripts": {
-    "build": "babel -s inline -d . src/",
-    "lint": "eslint .",
+    "build": "node_modules/.bin/babel -s inline -d . src/",
+    "lint": "node_modules/.bin/eslint .",
     "prepublish": "npm run build",
-    "spec": "NODE_ENV=test mocha --compilers js:babel-core/register -r adana-dump -R spec test/spec",
+    "spec": "NODE_ENV=test node_modules/.bin/mocha --compilers js:babel-core/register -r adana-dump -R spec test/spec",
     "test": "npm run lint && npm run spec"
   },
   "dependencies": {
@@ -23,15 +23,15 @@
     "adana-format-lcov": "^0.1.1",
     "babel-cli": "^6.4.0",
     "babel-core": "^6.3.26",
-    "babel-preset-metalab": "^0.1.4",
+    "babel-preset-metalab": "^0.2.0",
     "chai": "^3.4.0",
     "eslint": "^1.10.3",
     "eslint-config-metalab": "^1.0.0-rc.4",
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-import": "^0.11.0",
-    "eslint-plugin-react": "^3.15.0",
+    "eslint-plugin-react": "^3.16.1",
     "mocha": "^2.3.3",
-    "redux": "^3.0.5",
+    "redux": "^3.0.6",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   }

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -13,7 +13,6 @@ export default ({
 
     return {
       ...store,
-      liftedStore: store,
       [storeName]: waitStore,
       dispatch(action) {
         const promise = handleAction(action);

--- a/test/spec/enhancer.spec.js
+++ b/test/spec/enhancer.spec.js
@@ -59,25 +59,6 @@ describe('enhancer',  () => {
     });
   });
 
-  describe('original store', () => {
-    it('should be available at `liftedStore`', () => {
-      expect(store.liftedStore).to.be.an.object;
-    });
-
-    it('should have the original dispatch', () => {
-      const promise = Promise.resolve();
-      const asyncAction = { type: 'TEST', payload: promise };
-
-      store.liftedStore.dispatch({ type: 'INCREMENT' });
-      expect(store.getState()).to.equal(1);
-
-      expect(store.waitStore.getState().actions).to.deep.equal([]);
-      store.liftedStore.dispatch(asyncAction);
-
-      expect(store.waitStore.getState().actions).to.deep.equal([]);
-    });
-  });
-
   describe('`storeName` option', () => {
     it('should set the name of the wait store', () => {
       const namedStore = enhancer({


### PR DESCRIPTION
Breaking change. Remove `liftedStore` property.

Redux DevTools already sets a `liftedStore` property on the store object. Setting our own `liftedStore` breaks DevTools.

Update package deps.

Use absolute path to `node_modules` in package scripts.